### PR TITLE
Ignore `Gemfile.lock` for development is in early phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ esdata/
 tmp
 node_modules/
 log/
+Gemfile.lock
 
 etc/embulk/bin/
 etc/embulk/jruby/


### PR DESCRIPTION
We can ignore it because I guess the development phase is in early.

Or if you want to lock all gem's versions for stable development, we should manage `Gemfile.lock` in the git repository.
